### PR TITLE
Added customization of the label

### DIFF
--- a/MMM-PiTemp.js
+++ b/MMM-PiTemp.js
@@ -1,12 +1,13 @@
 Module.register("MMM-PiTemp", {
 	defaults: {
-	tempUnit: "C",
+		tempUnit: "C",
     	freq: 60000,
     	high: 80,
     	low: 70,
     	highColor: "red",
     	lowColor: "green",
-    	otherColor: "yellow"
+    	otherColor: "yellow",
+		label: "CPU:"
 	},
 	
 	start: function() {
@@ -30,16 +31,25 @@ Module.register("MMM-PiTemp", {
 	},
 
   	socketNotificationReceived: function(notification, payload) {
-		switch(notification) {
-      			case "temperature":
-        		var e = document.getElementById("pi_temp")
-			if (parseFloat(payload) <= this.config.low) {e.style.color = this.config.lowColor;}
-			else if (parseFloat(payload) >= this.config.high) {e.style.color = this.config.highColor}
-			else {e.style.color = this.config.otherColor}
+		switch (notification) {
+			case "temperature":
+				var e = document.getElementById("pi_temp");
+				if (parseFloat(payload) <= this.config.low) {
+					e.style.color = this.config.lowColor;
+				} else if (parseFloat(payload) >= this.config.high) {
+					e.style.color = this.config.highColor;
+				} else {
+					e.style.color = this.config.otherColor;
+				}
 
-			if (this.config.tempUnit === "C"){e.innerHTML = "CPU: " + payload.toString() + "°C";}
-			else {e.innerHTML = "CPU: " + (payload * (9/5) + 32).toFixed(1).toString() + "°F";}
-       			break;
+				var temp;
+				if (this.config.tempUnit === "C") {
+					temp = payload.toString() + "°C";
+				} else {
+					temp = (payload * (9 / 5) + 32).toFixed(1).toString() + "°F";
+				}
+				e.innerHTML = this.config.label + " " + temp;
+				break;
 		}
   	},
 })


### PR DESCRIPTION
I've extracted "CPU" label into the config allowing customization.
For example, I've changed my config to utilize Raspberry Pi icon from fontawesome
`config: {label: "<i class='fab fa-raspberry-pi'></i>"}`
to get this:
![rpi icon](https://i.imgur.com/JtfXnic.png)
Thought that might be useful.